### PR TITLE
add empty response and GrpcResponseHandler tests

### DIFF
--- a/extensions-contrib/grpc-query/src/test/java/org/apache/druid/grpc/client/GrpcResponseHandlerTest.java
+++ b/extensions-contrib/grpc-query/src/test/java/org/apache/druid/grpc/client/GrpcResponseHandlerTest.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+package org.apache.druid.grpc.client;
+
+import com.google.protobuf.ByteString;
+import org.apache.druid.grpc.proto.QueryOuterClass.QueryResponse;
+import org.apache.druid.grpc.proto.TestResults.QueryResult;
+import org.junit.BeforeClass;
+import org.junit.Test;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+public class GrpcResponseHandlerTest
+{
+  private static List<QueryResult> EXPECTED_RESULTS = new ArrayList<>();
+
+  @BeforeClass
+  public static void setup()
+  {
+    EXPECTED_RESULTS.add(QueryResult.newBuilder().setDim1("test").setCnt(100).build());
+    EXPECTED_RESULTS.add(QueryResult.newBuilder().setDim2("test2").setCnt(100).setM2(200.10).build());
+  }
+
+  @Test
+  public void testEmptyResponse()
+  {
+    GrpcResponseHandler<QueryResult> handler = GrpcResponseHandler.of(QueryResult.class);
+    List<QueryResult> queryResults = handler.get(ByteString.EMPTY);
+    assertTrue(queryResults.isEmpty());
+  }
+
+  @Test
+  public void testNonEmptysponse()
+  {
+    GrpcResponseHandler<QueryResult> handler = GrpcResponseHandler.of(QueryResult.class);
+    QueryResponse queryResponse = getQueryResponse();
+    List<QueryResult> queryResults = handler.get(queryResponse.getData());
+    assertEquals(2, queryResults.size());
+    assertEquals(EXPECTED_RESULTS, queryResults);
+  }
+  
+  private static QueryResponse getQueryResponse()
+  {
+    try {
+      final ByteArrayOutputStream out = new ByteArrayOutputStream();
+      for (QueryResult queryResult : EXPECTED_RESULTS) {
+        queryResult.writeDelimitedTo(out);
+      }
+      return QueryResponse.newBuilder()
+              .setData(ByteString.copyFrom(out.toByteArray()))
+              .build();
+    }
+    catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}


### PR DESCRIPTION
<!-- Thanks for trying to help us make Apache Druid be the best it can be! Please fill out as much of the following information as is possible (where relevant, and remove it when irrelevant) to help make the intention and scope of this PR clear in order to ease review. -->

<!-- Please read the doc for contribution (https://github.com/apache/druid/blob/master/CONTRIBUTING.md) before making this PR. Also, once you open a PR, please _avoid using force pushes and rebasing_ since these make it difficult for reviewers to see what you've changed in response to their reviews. See [the 'If your pull request shows conflicts with master' section](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#if-your-pull-request-shows-conflicts-with-master) for more details. -->

### Description
Adding tests for empty responses and GrpcResponseHandler.

<!--
In each section, please describe design decisions made, including:
 - Choice of algorithms
 - Behavioral aspects. What configuration values are acceptable? How are corner cases and error conditions handled, such as when there are insufficient resources?
 - Class organization and design (how the logic is split between classes, inheritance, composition, design patterns)
 - Method organization and design (how the logic is split between methods, parameters and return types)
 - Naming (class, method, API, configuration, HTTP endpoint, names of emitted metrics)
-->


<!-- It's good to describe an alternative design (or mention an alternative name) for every design (or naming) decision point and compare the alternatives with the designs that you've implemented (or the names you've chosen) to highlight the advantages of the chosen designs and names. -->

<!-- If there was a discussion of the design of the feature implemented in this PR elsewhere (e. g. a "Proposal" issue, any other issue, or a thread in the development mailing list), link to that discussion from this PR description and explain what have changed in your final design compared to your original proposal or the consensus version in the end of the discussion. If something hasn't changed since the original discussion, you can omit a detailed discussion of those aspects of the design here, perhaps apart from brief mentioning for the sake of readability of this PR description. -->

<!-- Some of the aspects mentioned above may be omitted for simple and small changes. -->
<!-- Give your best effort to summarize your changes in a couple of sentences aimed toward Druid users. 

If your change doesn't have end user impact, you can skip this section.

For tips about how to write a good release note, see [Release notes](https://github.com/apache/druid/blob/master/CONTRIBUTING.md#release-notes).

-->


<hr>

##### Key changed/added classes in this PR
 * `GrpcQueryTest`
 * `GrpcResponseHandlerTest`

<hr>

<!-- Check the items by putting "x" in the brackets for the done things. Not all of these items apply to every PR. Remove the items which are not done or not relevant to the PR. None of the items from the checklist below are strictly necessary, but it would be very helpful if you at least self-review the PR. -->

This PR has:

- [x] been self-reviewed.
- [x] added documentation for new or modified features or behaviors.
- [ ] a release note entry in the PR description.
- [x] added Javadocs for most classes and all non-trivial methods. Linked related entities via Javadoc links.
- [ ] added or updated version, license, or notice information in [licenses.yaml](https://github.com/apache/druid/blob/master/dev/license.md)
- [x] added comments explaining the "why" and the intent of the code wherever would not be obvious for an unfamiliar reader.
- [x] added unit tests or modified existing tests to cover new code paths, ensuring the threshold for [code coverage](https://github.com/apache/druid/blob/master/dev/code-review/code-coverage.md) is met.
- [ ] added integration tests.
- [ ] been tested in a test Druid cluster.
